### PR TITLE
Make monitored EntityTypes configurable

### DIFF
--- a/src/main/java/nl/pim16aap2/horses/Config.java
+++ b/src/main/java/nl/pim16aap2/horses/Config.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.horses;
 import nl.pim16aap2.horses.util.IReloadable;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -22,6 +24,9 @@ import java.util.Set;
 public class Config implements IReloadable
 {
     private static final String DEFAULT_GAITS = "0,25,35,50,75,100";
+
+    private static final Set<EntityType> DEFAULT_MONITORED_TYPES =
+        EnumSet.of(EntityType.HORSE, EntityType.MULE, EntityType.DONKEY);
 
     private final JavaPlugin javaPlugin;
 
@@ -45,6 +50,7 @@ public class Config implements IReloadable
     private boolean allowFeeding = true;
     private Set<Material> foodItems = Collections.emptySet();
     private Map<Material, Float> babyFoodMap = Collections.emptyMap();
+    private final Set<EntityType> monitoredTypes = Collections.unmodifiableSet(DEFAULT_MONITORED_TYPES);
 
     private final Path path;
 
@@ -317,5 +323,10 @@ public class Config implements IReloadable
     public Set<Material> getFoodItems()
     {
         return foodItems;
+    }
+
+    public Set<EntityType> getMonitoredTypes()
+    {
+        return monitoredTypes;
     }
 }

--- a/src/main/java/nl/pim16aap2/horses/Horses.java
+++ b/src/main/java/nl/pim16aap2/horses/Horses.java
@@ -2,22 +2,16 @@ package nl.pim16aap2.horses;
 
 import nl.pim16aap2.horses.util.IReloadable;
 import nl.pim16aap2.horses.util.Localizer;
-import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 @SuppressWarnings("unused")
 public class Horses extends JavaPlugin
 {
-    public static final Set<EntityType> MONITORED_TYPES =
-        EnumSet.of(EntityType.HORSE, EntityType.MULE, EntityType.DONKEY);
-
     private static @Nullable Horses instance;
 
     private final HorsesComponent horsesComponent;

--- a/src/main/java/nl/pim16aap2/horses/commands/CommandListener.java
+++ b/src/main/java/nl/pim16aap2/horses/commands/CommandListener.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.horses.commands;
 
 import nl.pim16aap2.horses.Communicator;
+import nl.pim16aap2.horses.Config;
 import nl.pim16aap2.horses.HorseEditor;
 import nl.pim16aap2.horses.Horses;
 import nl.pim16aap2.horses.util.IReloadable;
@@ -34,17 +35,22 @@ public class CommandListener implements CommandExecutor
     private final Localizer localizer;
     private final AttributeMapper attributeMapper;
     private final Communicator communicator;
+    private final Config config;
 
-    @Inject
-    public CommandListener(
-        Horses horses, HorseEditor horseEditor, Localizer localizer, AttributeMapper attributeMapper,
-        Communicator communicator)
+    @Inject CommandListener(
+        Horses horses,
+        HorseEditor horseEditor,
+        Localizer localizer,
+        AttributeMapper attributeMapper,
+        Communicator communicator,
+        Config config)
     {
         this.horses = horses;
         this.horseEditor = horseEditor;
         this.localizer = localizer;
         this.attributeMapper = attributeMapper;
         this.communicator = communicator;
+        this.config = config;
     }
 
     @Override
@@ -130,7 +136,7 @@ public class CommandListener implements CommandExecutor
 
         final @Nullable Entity entity = Bukkit.getEntity(uuid);
         if (!(entity instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()))
+            !config.getMonitoredTypes().contains(horse.getType()))
         {
             sender.sendMessage(localizer.get("commands.error.no_horses_found", uuid.toString()));
             return;

--- a/src/main/java/nl/pim16aap2/horses/horsetracker/HorseTracker.java
+++ b/src/main/java/nl/pim16aap2/horses/horsetracker/HorseTracker.java
@@ -130,7 +130,7 @@ public class HorseTracker
         {
             final @Nullable Entity vehicle = player.getVehicle();
             if (vehicle != null &&
-                Horses.MONITORED_TYPES.contains(vehicle.getType()) &&
+                config.getMonitoredTypes().contains(vehicle.getType()) &&
                 vehicle instanceof AbstractHorse horse)
                 trackHorse(player, horse);
         }

--- a/src/main/java/nl/pim16aap2/horses/listeners/FeedListener.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/FeedListener.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.horses.listeners;
 
 import nl.pim16aap2.horses.Config;
-import nl.pim16aap2.horses.Horses;
 import nl.pim16aap2.horses.baby.BabyHandler;
 import nl.pim16aap2.horses.util.Localizer;
 import nl.pim16aap2.horses.util.Permission;
@@ -45,7 +44,7 @@ class FeedListener implements Listener
     public void onFeed(PlayerInteractEntityEvent event)
     {
         if (!(event.getRightClicked() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()))
+            !config.getMonitoredTypes().contains(horse.getType()))
             return;
 
         final ItemStack item = event.getPlayer().getInventory().getItem(event.getHand());

--- a/src/main/java/nl/pim16aap2/horses/listeners/HorseListener.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/HorseListener.java
@@ -5,7 +5,6 @@ import nl.pim16aap2.horses.Communicator;
 import nl.pim16aap2.horses.Config;
 import nl.pim16aap2.horses.HorseEditor;
 import nl.pim16aap2.horses.HorseGender;
-import nl.pim16aap2.horses.Horses;
 import nl.pim16aap2.horses.baby.BabyHandler;
 import nl.pim16aap2.horses.horseselector.SelectorToolUtil;
 import nl.pim16aap2.horses.horsetracker.HorseTracker;
@@ -75,7 +74,7 @@ class HorseListener implements Listener
     {
         if (!(event.getDamager() instanceof Player player) ||
             !(event.getEntity() instanceof AbstractHorse horse) ||
-            !(Horses.MONITORED_TYPES.contains(horse.getType())))
+            !(config.getMonitoredTypes().contains(horse.getType())))
             return;
 
         if (player.getInventory().getItemInMainHand().getType() != Material.SHEARS)
@@ -125,7 +124,7 @@ class HorseListener implements Listener
     private boolean processInfoClick(Player player, Entity target)
     {
         if (!(target instanceof AbstractHorse horse) ||
-            !(Horses.MONITORED_TYPES.contains(target.getType())))
+            !(config.getMonitoredTypes().contains(target.getType())))
             return false;
 
         final ItemStack holding = player.getInventory().getItemInMainHand();
@@ -156,7 +155,7 @@ class HorseListener implements Listener
     public void onSpawn(EntitySpawnEvent event)
     {
         if (!(event.getEntity() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()))
+            !config.getMonitoredTypes().contains(horse.getType()))
             return;
 
         if (horse.isAdult())
@@ -169,9 +168,9 @@ class HorseListener implements Listener
     public void onBreed(EntityBreedEvent event)
     {
         if (!(event.getFather() instanceof AbstractHorse father) ||
-            !Horses.MONITORED_TYPES.contains(father.getType()) ||
+            !config.getMonitoredTypes().contains(father.getType()) ||
             !(event.getMother() instanceof AbstractHorse mother) ||
-            !Horses.MONITORED_TYPES.contains(mother.getType()) ||
+            !config.getMonitoredTypes().contains(mother.getType()) ||
             !(event.getEntity() instanceof AbstractHorse child))
             return;
         event.setCancelled(!babyHandler.newBaby(child, father, mother));
@@ -180,7 +179,7 @@ class HorseListener implements Listener
     @EventHandler(ignoreCancelled = true)
     public void onDeath(EntityDeathEvent event)
     {
-        if (!Horses.MONITORED_TYPES.contains(event.getEntityType()))
+        if (!config.getMonitoredTypes().contains(event.getEntityType()))
             return;
         event.getDrops().removeIf(itemStack -> itemStack.getType().equals(Material.LEATHER));
     }
@@ -189,7 +188,7 @@ class HorseListener implements Listener
     public void onDismount(EntityDismountEvent event)
     {
         if (!(event.getDismounted() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()))
+            !config.getMonitoredTypes().contains(horse.getType()))
             return;
 
         if (config.getResetGait() >= 0)
@@ -209,7 +208,7 @@ class HorseListener implements Listener
     public void onMount(EntityMountEvent event)
     {
         if (!(event.getMount() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()) ||
+            !config.getMonitoredTypes().contains(horse.getType()) ||
             !(event.getEntity() instanceof Player player))
             return;
 

--- a/src/main/java/nl/pim16aap2/horses/listeners/LeadRestrictionListener.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/LeadRestrictionListener.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.horses.listeners;
 
-import nl.pim16aap2.horses.Horses;
+import nl.pim16aap2.horses.Config;
 import nl.pim16aap2.horses.util.Localizer;
 import nl.pim16aap2.horses.util.Permission;
 import nl.pim16aap2.horses.util.Util;
@@ -19,17 +19,19 @@ import javax.inject.Singleton;
 public class LeadRestrictionListener implements Listener
 {
     private final Localizer localizer;
+    private final Config config;
 
-    @Inject LeadRestrictionListener(Localizer localizer)
+    @Inject LeadRestrictionListener(Localizer localizer, Config config)
     {
         this.localizer = localizer;
+        this.config = config;
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onLeadAttach(PlayerLeashEntityEvent event)
     {
         if (!(event.getEntity() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()))
+            !config.getMonitoredTypes().contains(horse.getType()))
             return;
 
         final Player player = event.getPlayer();

--- a/src/main/java/nl/pim16aap2/horses/listeners/ListenerManager.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/ListenerManager.java
@@ -106,6 +106,7 @@ public class ListenerManager implements IReloadable
     {
         initCommands(
             "ReloadHorses",
+            "ListHorseTypes",
             "GetHorseInfo");
         initCommand("EditHorse", tabCompleter);
     }

--- a/src/main/java/nl/pim16aap2/horses/listeners/PotionListener.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/PotionListener.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.horses.listeners;
 
-import nl.pim16aap2.horses.Horses;
+import nl.pim16aap2.horses.Config;
 import nl.pim16aap2.horses.util.Util;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
@@ -17,15 +17,18 @@ import javax.inject.Singleton;
 @Singleton
 class PotionListener implements Listener
 {
-    @Inject PotionListener()
+    private final Config config;
+
+    @Inject PotionListener(Config config)
     {
+        this.config = config;
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onMount(EntityMountEvent event)
     {
         if (!(event.getMount() instanceof AbstractHorse horse) ||
-            !Horses.MONITORED_TYPES.contains(horse.getType()) ||
+            !config.getMonitoredTypes().contains(horse.getType()) ||
             !(event.getEntity() instanceof Player player))
             return;
 
@@ -40,7 +43,7 @@ class PotionListener implements Listener
             return;
 
         if (event.getEntity() instanceof Player player && Util.getHorseRiddenByPlayer(player) != null ||
-            Horses.MONITORED_TYPES.contains(event.getEntity().getType()))
+            config.getMonitoredTypes().contains(event.getEntity().getType()))
             event.setCancelled(true);
     }
 }

--- a/src/main/java/nl/pim16aap2/horses/listeners/SelectorToolListener.java
+++ b/src/main/java/nl/pim16aap2/horses/listeners/SelectorToolListener.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.horses.listeners;
 
-import nl.pim16aap2.horses.Horses;
+import nl.pim16aap2.horses.Config;
 import nl.pim16aap2.horses.horseselector.HorseSelectorManager;
 import nl.pim16aap2.horses.horseselector.SelectorToolUtil;
 import org.bukkit.entity.AbstractHorse;
@@ -27,11 +27,15 @@ class SelectorToolListener implements Listener
 {
     private final SelectorToolUtil selectorToolUtil;
     private final HorseSelectorManager horseSelectorManager;
+    private final Config config;
 
-    @Inject SelectorToolListener(SelectorToolUtil selectorToolUtil, HorseSelectorManager horseSelectorManager)
+    @Inject SelectorToolListener(
+        SelectorToolUtil selectorToolUtil, HorseSelectorManager horseSelectorManager,
+        Config config)
     {
         this.selectorToolUtil = selectorToolUtil;
         this.horseSelectorManager = horseSelectorManager;
+        this.config = config;
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
@@ -39,7 +43,7 @@ class SelectorToolListener implements Listener
     {
         if (!(event.getDamager() instanceof Player player) ||
             !(event.getEntity() instanceof AbstractHorse horse) ||
-            !(Horses.MONITORED_TYPES.contains(horse.getType())))
+            !(config.getMonitoredTypes().contains(horse.getType())))
             return;
 
         if (!selectorToolUtil.isSelectorTool(player.getInventory().getItemInMainHand()))

--- a/src/main/java/nl/pim16aap2/horses/util/Util.java
+++ b/src/main/java/nl/pim16aap2/horses/util/Util.java
@@ -2,12 +2,14 @@ package nl.pim16aap2.horses.util;
 
 import nl.pim16aap2.horses.Horses;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 
 public final class Util
@@ -32,7 +34,7 @@ public final class Util
     public static @Nullable AbstractHorse getHorseRiddenByPlayer(Player player)
     {
         if (player.getVehicle() != null &&
-            Horses.MONITORED_TYPES.contains(player.getVehicle().getType()) &&
+            getMonitoredTypes().contains(player.getVehicle().getType()) &&
             player.getVehicle() instanceof AbstractHorse horse)
             return horse;
         return null;
@@ -97,11 +99,16 @@ public final class Util
     public static List<AbstractHorse> getLeadHorses(Player player, int range)
     {
         return player.getNearbyEntities(range, range, range).stream()
-                     .filter(entity -> Horses.MONITORED_TYPES.contains(entity.getType()))
+                     .filter(entity -> getMonitoredTypes().contains(entity.getType()))
                      .map(AbstractHorse.class::cast)
                      .filter(AbstractHorse::isLeashed)
                      .filter(horse -> player.equals(horse.getLeashHolder()))
                      .toList();
+    }
+
+    private static Set<EntityType> getMonitoredTypes()
+    {
+        return Horses.instance().getHorsesComponent().getConfig().getMonitoredTypes();
     }
 
     public static List<AbstractHorse> getLeadAndRiddenHorses(Player player)

--- a/src/main/java/nl/pim16aap2/horses/util/Util.java
+++ b/src/main/java/nl/pim16aap2/horses/util/Util.java
@@ -7,6 +7,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -14,6 +17,9 @@ import java.util.UUID;
 
 public final class Util
 {
+    private static final Set<EntityType> SUPPORTED_ENTITY_TYPES =
+        Collections.unmodifiableSet(findSupportedEntityTypes());
+
     private Util()
     {
         // Utility class
@@ -126,5 +132,27 @@ public final class Util
             ret.add(riddenHorse);
         }
         return ret;
+    }
+
+    /**
+     * Gets a list of all supported entity types on the current version of Minecraft.
+     *
+     * @return A list of possible entity types.
+     */
+    public static Set<EntityType> getSupportedEntityTypes()
+    {
+        return SUPPORTED_ENTITY_TYPES;
+    }
+
+    private static Set<EntityType> findSupportedEntityTypes()
+    {
+        final Set<EntityType> tmp = new HashSet<>();
+        for (final var entityType : EntityType.values())
+        {
+            final @Nullable Class<?> entityClass = entityType.getEntityClass();
+            if (entityClass != null && AbstractHorse.class.isAssignableFrom(entityType.getEntityClass()))
+                tmp.add(entityType);
+        }
+        return EnumSet.copyOf(tmp);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -73,3 +73,11 @@ allowFeeding: true
 # The format is a list of materials separated by ';', e.g.: APPLE:GOLDEN_APPLE
 # Breeding items (i.e. golden apples/carrots) are ignored and are handled as normal.
 foodItems: APPLE;WHEAT
+
+# A list of all the types of entities that should be monitored by this plugin.
+# All types in this list will be affected by the plugin's features.
+# Use the command "/ListHorseTypes" to get a list of all possible types.
+monitoredTypes:
+  - donkey
+  - horse
+  - mule

--- a/src/main/resources/horses_messages.properties
+++ b/src/main/resources/horses_messages.properties
@@ -50,4 +50,5 @@ commands.error.no_horses_targeted=You are not currently leading or riding any ho
 commands.error.no_horses_found=Could not find any horses with UUID "{0}"!
 commands.success.attribute_updated=Attribute "{0}" has been updated!
 commands.success.plugin_reloaded=Plugin has been reloaded!
+commands.success.monitored_types=List of supported types ('+' = monitored, '-' = ignored): {0}
 message.instruction.click_to_see_parent=Click here!

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ commands:
     description: Edits an attribute of a horse.
     permission: horses.admin.edit
     usage: /EditHorse <Attribute> [Value]
+  listhorsetypes:
+    description: Lists all available horse types.
+    permission: horses.admin.list_types
   gethorseinfo:
     description: Gets the information of a horse.
     permission: horses.user.see_info_menu


### PR DESCRIPTION
- The configuration was extended with a new option: `monitoredTypes`. This option accepts any `EntityType` name whose `entityClass` is a subclass of `AbstractHorse`.
- A new command was added to list all supported entity types on the current version of Minecraft: `/ListHorseTypes`.

The default config option is this:
```yaml
# A list of all the types of entities that should be monitored by this plugin.
# All types in this list will be affected by the plugin's features.
# Use the command "/ListHorseTypes" to get a list of all possible types.
monitoredTypes:
  - donkey
  - horse
  - mule
```